### PR TITLE
Migrate remaining CLI usage to lstk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,25 +20,29 @@ jobs:
             # Currently highest available 3.11 on CircleCI runner
             test -d /opt/circleci/.pyenv/versions/3.11.1 || pyenv install 3.11.1
             pyenv global 3.11.1
-      - localstack/start        
+      - run:
+          name: Install lstk
+          command: npm install -g @localstack/lstk
       - run:
           name: Install dependencies
           command:
             pip3 install -r requirements-dev.txt --upgrade
-      - localstack/wait
+      - run:
+          name: Start LocalStack
+          command: lstk start
       - run:
           name: Build lambdas
           command:
             deployment/build-lambdas.sh
-            
+
       - run:
           name: Deploy infrastructure
           command:
-            deployment/awslocal/deploy.sh
-            
+            deployment/aws/deploy.sh
+
       - run:
           name: Export state
-          command: localstack state export ls-state.zip
+          command: lstk save ls-state.zip
       - persist_to_workspace:
           root: .
           paths:
@@ -58,8 +62,8 @@ jobs:
         AWS_REGION: us-east-1
         AWS_ACCESS_KEY_ID: test
         AWS_SECRET_ACCESS_KEY: test
-        DEBUG: 1
-        LS_LOG: trace
+        LOCALSTACK_DEBUG: 1
+        LOCALSTACK_LS_LOG: trace
     steps:
       - restore_cache:
           key: python-deps-
@@ -67,18 +71,22 @@ jobs:
           name: Choose python version
           command:
             pyenv global 3.11.1
-      - localstack/start        
+      - run:
+          name: Install lstk
+          command: npm install -g @localstack/lstk
       - checkout
       - run:
           name: Install dependencies
           command:
             pip3 install -r requirements-dev.txt
-      - localstack/wait
+      - run:
+          name: Start LocalStack
+          command: lstk start
       - attach_workspace:
           at: .
       - run:
           name: Import state
-          command: test -f ls-state.zip && localstack state import ls-state.zip
+          command: test -f ls-state.zip && lstk load ls-state.zip
       - run:
           name: Run Tests
           command:
@@ -86,7 +94,7 @@ jobs:
       - run:
           when: on_fail
           name: Dump Localstack logs
-          command: localstack logs | tee localstack.log
+          command: lstk logs | tee localstack.log
       - store_artifacts:
           path: localstack.log
 

--- a/.devcontainer/docker-in-docker/devcontainer.json
+++ b/.devcontainer/docker-in-docker/devcontainer.json
@@ -3,7 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/base:jammy",
 
 	"remoteEnv": {
-		// Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
+		// Activate LocalStack Pro: https://docs.localstack.cloud/aws/getting-started/auth-token/
 		"LOCALSTACK_AUTH_TOKEN": "${localEnv:LOCALSTACK_AUTH_TOKEN}",  // required for Pro, not processed via template due to security reasons
 		"LOCALSTACK_API_KEY": "${localEnv:LOCALSTACK_API_KEY}",
 		// LocalStack configuration: https://docs.localstack.cloud/references/configuration/
@@ -21,6 +21,8 @@
 	},
 
 	// 👇 Features to add to the Dev Container. More info: https://containers.dev/implementors/features.
+	// NOTE(lstk): the localstack-cli feature below installs the legacy `localstack` CLI and
+	// *local wrappers, not lstk — there is no lstk-based devcontainer feature yet.
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/localstack/devcontainer-feature/localstack-cli:latest": {

--- a/.devcontainer/docker-outside-of-docker/.env
+++ b/.devcontainer/docker-outside-of-docker/.env
@@ -1,4 +1,4 @@
-# Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
+# Activate LocalStack Pro: https://docs.localstack.cloud/aws/getting-started/auth-token/
 LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}  # required for Pro, not processed via template due to security reasons
 LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY:-}
 # LocalStack configuration: https://docs.localstack.cloud/references/configuration/

--- a/.devcontainer/docker-outside-of-docker/devcontainer.json
+++ b/.devcontainer/docker-outside-of-docker/devcontainer.json
@@ -5,6 +5,8 @@
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
 	// 👇 Features to add to the Dev Container. More info: https://containers.dev/implementors/features.
+	// NOTE(lstk): the localstack-cli feature below installs the legacy `localstack` CLI and
+	// *local wrappers, not lstk — there is no lstk-based devcontainer feature yet.
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
 		"ghcr.io/localstack/devcontainer-feature/localstack-cli:latest": {

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Start LocalStack
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
-          DEBUG: 1
+          LOCALSTACK_DEBUG: 1
         run: |
           lstk start --type aws
 
@@ -128,7 +128,7 @@ jobs:
       - name: Start LocalStack
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
-          DEBUG: 1
+          LOCALSTACK_DEBUG: 1
         run: |
           lstk start --type aws
 

--- a/.github/workflows/test_snapshots.yml
+++ b/.github/workflows/test_snapshots.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Start LocalStack
         env:
-          DEBUG: 1
+          LOCALSTACK_DEBUG: 1
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           lstk start --type aws
@@ -92,7 +92,7 @@ jobs:
 
       - name: Start LocalStack
         env:
-          DEBUG: 1
+          LOCALSTACK_DEBUG: 1
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           lstk start --type aws

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,9 +13,9 @@ variables:
   PIP_CACHE_DIR: $CI_PROJECT_DIR/.cache/pip
   DOCKER_HOST: tcp://docker:2375
   DOCKER_TLS_CERTDIR: ""
-  DEBUG: 1
-  LS_LOG: trace
-  LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT: 300
+  LOCALSTACK_DEBUG: 1
+  LOCALSTACK_LS_LOG: trace
+  LOCALSTACK_LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT: 300
 
 services:
   - name: docker:24.0.7-dind-alpine3.18
@@ -25,19 +25,19 @@ services:
 default:
   before_script: &default_before_scripts
     - apk update
-    - apk add --no-cache gcc musl-dev linux-headers bash zip jq curl py3-psutil python3
+    - apk add --no-cache gcc musl-dev linux-headers bash zip jq curl py3-psutil python3 nodejs npm
     - python3 -m ensurepip
     - python3 -m pip install --no-cache --upgrade pip setuptools
     - mkdir -p $PIP_CACHE_DIR
-    - python3 -m pip install localstack awscli awscli-local
+    - python3 -m pip install awscli
+    - npm install -g @localstack/lstk
     - docker pull localstack/localstack-pro:latest
     # Gitlab has changed to ipv6, but LocalStack does not support it
     - dind_ip="$(getent ahostsv4 docker | cut -d' ' -f1 | head -n1)"
     - echo -e "${dind_ip}\tlocalhost.localstack.cloud\n" >> /etc/hosts
-    - localstack start -d
-    - localstack wait -t 30
+    - lstk start
     - mkdir -p /usr/lib/localstack
-    - (test -f ./ls-state-pod.zip && localstack state import ./ls-state-pod.zip) || true
+    - (test -f ./ls-state-pod.zip && lstk load ./ls-state-pod.zip) || true
   cache:
     paths:
       - $CI_PROJECT_DIR/.cache/pip
@@ -58,9 +58,9 @@ deploy:
     - when: always
   script:
     - ./deployment/build-lambdas.sh
-    - ./deployment/awslocal/deploy.sh
+    - ./deployment/aws/deploy.sh
     - mkdir -p /usr/lib/localstack
-    - localstack state export ls-state-pod.zip
+    - lstk save ls-state-pod.zip
 
 test:
   stage: test
@@ -78,4 +78,4 @@ test:
     - *default_before_scripts
     - python3 -m pip install -r requirements-dev.txt
   script:
-    - python3 -m pytest tests || (localstack logs && exit 1)
+    - python3 -m pytest tests || (lstk logs && exit 1)

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The following diagram shows the architecture that this sample application builds
 
 ## Prerequisites
 
-- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
-- [`lstk` CLI](https://docs.localstack.cloud/aws/tooling/lstk/).
-- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`lstk aws` proxy](https://docs.localstack.cloud/aws/tooling/lstk/).
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/aws/getting-started/auth-token/) to activate LocalStack.
+- [`lstk` CLI](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/).
+- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`lstk aws` proxy](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/).
 - [Python 3.11](https://www.python.org/downloads/) (same version as the Lambda runtime)
 - [`make`](https://www.gnu.org/software/make/) for running the sample application via the provided Makefile
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,8 +6,8 @@ env:
     AWS_REGION: us-east-1
     AWS_ACCESS_KEY_ID: test
     AWS_SECRET_ACCESS_KEY: test
-    DEBUG: 1
-    LS_LOG: trace
+    LOCALSTACK_DEBUG: 1
+    LOCALSTACK_LS_LOG: trace
   parameter-store:
     LOCALSTACK_AUTH_TOKEN: /CodeBuild/LOCALSTACK_AUTH_TOKEN
 
@@ -15,23 +15,24 @@ phases:
   install:
     runtime-versions:
       python: 3.11
+      nodejs: latest
     commands:
       - test -d /root/.pyenv/versions/3.11.6 || pyenv install 3.11.6
       - pyenv global 3.11.6
       - pip install -r requirements-dev.txt
-      - pip install localstack
+      - npm install -g @localstack/lstk
       - docker pull public.ecr.aws/localstack/localstack-pro:latest
       - docker image tag public.ecr.aws/localstack/localstack-pro:latest localstack/localstack-pro:latest
-      - localstack start -d
+      - lstk start
   pre_build:
     commands:
       - deployment/build-lambdas.sh
-      - deployment/awslocal/deploy.sh
+      - deployment/aws/deploy.sh
   build:
     commands:
       - pytest tests
     finally:
-      - localstack logs
+      - lstk logs
 
 cache:
   paths:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,3 @@ mypy-boto3-lambda
 black
 pytest
 awscli
-awscli-local
-terraform-local


### PR DESCRIPTION
## Summary
- Finish the earlier partial migration: buildspec.yml (CodeBuild), .gitlab-ci.yml, and .circleci/config.yml now install and use `lstk` instead of the legacy CLI; `localstack state export/import` → `lstk save`/`lstk load`.
- Drop `awscli-local`/`terraform-local` from requirements-dev.txt; prefix forwarded env vars with `LOCALSTACK_`; fix stale doc links.
- Devcontainers keep the legacy-CLI feature with a NOTE — no lstk devcontainer feature exists yet.

## Testing
- CI workflow run on this branch.

Part of DEVX-1056

> Note: all four GitHub workflows pass. The `ci/circleci: save-state` check exercises the migrated CircleCI config on CircleCI's side — it was still queued at time of writing; if it fails, check that `LOCALSTACK_AUTH_TOKEN` is set in the CircleCI project settings.